### PR TITLE
画像ファイルの出力先を変更 #4

### DIFF
--- a/src/main/java/dandelion/MainController.java
+++ b/src/main/java/dandelion/MainController.java
@@ -1,5 +1,7 @@
 package dandelion;
 
+import com.typesafe.config.Config;
+import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
@@ -10,7 +12,14 @@ import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextField;
 
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
+/**
+ * メイン画面Controller
+ */
 public class MainController {
 
     @FXML
@@ -39,9 +48,37 @@ public class MainController {
         }
     }
 
+    /**
+     * スクリーンショット
+     */
     @FXML
     public void screenShot() {
-        SeleniumWrapper.getInstance().takeScreenShot();
+        SeleniumWrapper.getInstance().takeScreenShot(generatePath());
+    }
+
+    /**
+     * アプリケーションの終了
+     */
+    @FXML
+    public void quit() {
+        SeleniumWrapper.getInstance().quit();
+        Platform.exit();
+    }
+
+    /**
+     * 出力先パス生成
+     *
+     * ${dir}/${caseid}/${yyyyMMdd_hhmmss}.${extension}
+     *
+     * @return Path
+     */
+    public Path generatePath() {
+        Config output = ConfigUtils.load().getConfig("output");
+        String dir = output.getString("dirpath");
+        String caseid = output.getString("caseid");
+        String date = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_hhmmss"));
+        String ext = output.getString("image.extension");
+        return Paths.get(dir, caseid, date + "." + ext);
     }
 
 }

--- a/src/main/java/dandelion/SeleniumWrapper.java
+++ b/src/main/java/dandelion/SeleniumWrapper.java
@@ -8,6 +8,7 @@ import org.openqa.selenium.chrome.ChromeDriver;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * Selenium WebDriverの簡易wrapper.
@@ -60,12 +61,12 @@ public class SeleniumWrapper {
     /**
      * 起動済みのブラウザでスクリーンショットを撮る。
      */
-    public void takeScreenShot() {
+    public void takeScreenShot(Path outputPath) {
         System.out.println("= Screen Shot =");
         File img = ((TakesScreenshot)this.webDriverInstance).getScreenshotAs(OutputType.FILE);
         try {
-            System.out.println("Name : " + img.getName());
-            FileUtils.copyFile(img, new File(img.getName()));
+            FileUtils.copyFile(img, outputPath.toFile());
+            System.out.println("Name : " + outputPath.toFile().getAbsolutePath());
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/resources/dandelion/main.fxml
+++ b/src/main/resources/dandelion/main.fxml
@@ -12,7 +12,7 @@
           <Menu fx:id="menu" mnemonicParsing="false" text="File">
             <items>
                   <MenuItem fx:id="settings" mnemonicParsing="false" text="Settings" />
-              <MenuItem fx:id="close" mnemonicParsing="false" text="Close" />
+              <MenuItem fx:id="close" mnemonicParsing="false" onAction="#quit" text="Close" />
             </items>
           </Menu>
         </menus>


### PR DESCRIPTION
画像の出力先を設定ファイルから取得したり、ファイル名をyyyyMMdd_hhmmss.jpegとしたりした。

ついでにメイン画面のCloseを実装した。